### PR TITLE
CE-7623 Fix security alert on `postcss`

### DIFF
--- a/vue/demo/package-lock.json
+++ b/vue/demo/package-lock.json
@@ -9904,9 +9904,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
### Background 💡 


For some reason, GYG Bot has assigned https://github.com/getyourguide/se-tech-challenge/security/dependabot/5 to Customer Engagement **¯\\_(ツ)_/¯**

The issue happens on `postcss` < `8.4.31`

### Goal 🎯 

Update postcss from `8.4.24` to `8.4.31`

### Closes ☑️ 

- [ ] [CE-7623](https://getyourguide.atlassian.net/browse/CE-7623)
- [ ] https://github.com/getyourguide/se-tech-challenge/security/dependabot/5 


[CE-7623]: https://getyourguide.atlassian.net/browse/CE-7623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ