### PR TITLE
Docker: Make npm install work

### DIFF
--- a/vue-frontend/Dockerfile
+++ b/vue-frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Install dependencies
-FROM node:20-slim AS builder
+FROM node:20 AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm install


### PR DESCRIPTION
The `-slim` version doesn't contain docker [[link](https://github.com/nodejs/docker-node/issues/12#issuecomment-84025397)]. So for the first build phase we use the non slim version.
```
 > [vue-app builder 4/4] RUN npm install:
0.667 npm WARN EBADENGINE Unsupported engine {
0.667 npm WARN EBADENGINE   package: '@achrinza/node-ipc@9.2.6',
0.667 npm WARN EBADENGINE   required: {
0.667 npm WARN EBADENGINE     node: '8 || 9 || 10 || 11 || 12 || 13 || 14 || 15 || 16 || 17 || 18 || 19'
0.667 npm WARN EBADENGINE   },
0.667 npm WARN EBADENGINE   current: { node: 'v20.9.0', npm: '10.1.0' }
0.667 npm WARN EBADENGINE }
5.865 npm WARN deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
6.117 npm WARN deprecated @npmcli/move-file@2.0.1: This functionality has been moved to @npmcli/fs
6.158 npm WARN deprecated @npmcli/move-file@1.1.2: This functionality has been moved to @npmcli/fs
11.67 npm notice 
11.67 npm notice New minor version of npm available! 10.1.0 -> 10.2.1
11.67 npm notice Changelog: <https://github.com/npm/cli/releases/tag/v10.2.1>
11.67 npm notice Run `npm install -g npm@10.2.1` to update!
11.67 npm notice 
11.67 npm ERR! code 1
11.67 npm ERR! path /app/node_modules/node-sass
11.67 npm ERR! command failed
11.67 npm ERR! command sh -c node scripts/build.js
11.67 npm ERR! Binary found at /app/node_modules/node-sass/vendor/linux-arm64-115/binding.node
11.67 npm ERR! Testing binary
11.67 npm ERR! Binary has a problem: Error: /app/node_modules/node-sass/vendor/linux-arm64-115/binding.node: file too short
11.67 npm ERR!     at Module._extensions..node (node:internal/modules/cjs/loader:1327:18)
11.67 npm ERR!     at Module.load (node:internal/modules/cjs/loader:1091:32)
11.67 npm ERR!     at Module._load (node:internal/modules/cjs/loader:938:12)
11.67 npm ERR!     at Module.require (node:internal/modules/cjs/loader:1115:19)
11.67 npm ERR!     at require (node:internal/modules/helpers:130:18)
11.67 npm ERR!     at module.exports (/app/node_modules/node-sass/lib/binding.js:19:10)
11.67 npm ERR!     at Object.<anonymous> (/app/node_modules/node-sass/lib/index.js:13:35)
11.67 npm ERR!     at Module._compile (node:internal/modules/cjs/loader:1241:14)
11.67 npm ERR!     at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
11.67 npm ERR!     at Module.load (node:internal/modules/cjs/loader:1091:32) {
11.67 npm ERR!   code: 'ERR_DLOPEN_FAILED'
11.67 npm ERR! }
11.67 npm ERR! Building the binary locally
11.67 npm ERR! Building: /usr/local/bin/node /app/node_modules/node-gyp/bin/node-gyp.js rebuild --verbose --libsass_ext= --libsass_cflags= --libsass_ldflags= --libsass_library=
11.67 npm ERR! gyp info it worked if it ends with ok
11.67 npm ERR! gyp verb cli [
11.67 npm ERR! gyp verb cli   '/usr/local/bin/node',
11.67 npm ERR! gyp verb cli   '/app/node_modules/node-gyp/bin/node-gyp.js',
11.67 npm ERR! gyp verb cli   'rebuild',
11.67 npm ERR! gyp verb cli   '--verbose',
11.67 npm ERR! gyp verb cli   '--libsass_ext=',
11.67 npm ERR! gyp verb cli   '--libsass_cflags=',
11.67 npm ERR! gyp verb cli   '--libsass_ldflags=',
11.67 npm ERR! gyp verb cli   '--libsass_library='
11.67 npm ERR! gyp verb cli ]
11.67 npm ERR! gyp info using node-gyp@8.4.1
11.67 npm ERR! gyp info using node@20.9.0 | linux | arm64
11.67 npm ERR! gyp verb command rebuild []
11.67 npm ERR! gyp verb command clean []
11.67 npm ERR! gyp verb clean removing "build" directory
11.67 npm ERR! gyp verb command configure []
11.67 npm ERR! gyp verb find Python Python is not set from command line or npm configuration
11.67 npm ERR! gyp verb find Python Python is not set from environment variable PYTHON
11.67 npm ERR! gyp verb find Python checking if "python3" can be used
11.67 npm ERR! gyp verb find Python - executing "python3" to get executable path
11.68 npm ERR! gyp verb find Python - "python3" is not in PATH or produced an error
11.68 npm ERR! gyp verb find Python checking if "python" can be used
11.68 npm ERR! gyp verb find Python - executing "python" to get executable path
11.68 npm ERR! gyp verb find Python - "python" is not in PATH or produced an error
11.68 npm ERR! gyp ERR! find Python 
11.68 npm ERR! gyp ERR! find Python Python is not set from command line or npm configuration
11.68 npm ERR! gyp ERR! find Python Python is not set from environment variable PYTHON
11.68 npm ERR! gyp ERR! find Python checking if "python3" can be used
11.68 npm ERR! gyp ERR! find Python - "python3" is not in PATH or produced an error
11.68 npm ERR! gyp ERR! find Python checking if "python" can be used
11.68 npm ERR! gyp ERR! find Python - "python" is not in PATH or produced an error
11.68 npm ERR! gyp ERR! find Python 
11.68 npm ERR! gyp ERR! find Python **********************************************************
11.68 npm ERR! gyp ERR! find Python You need to install the latest version of Python.
11.68 npm ERR! gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
11.68 npm ERR! gyp ERR! find Python you can try one of the following options:
11.68 npm ERR! gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
11.68 npm ERR! gyp ERR! find Python   (accepted by both node-gyp and npm)
11.68 npm ERR! gyp ERR! find Python - Set the environment variable PYTHON
11.68 npm ERR! gyp ERR! find Python - Set the npm configuration variable python:
11.68 npm ERR! gyp ERR! find Python   npm config set python "/path/to/pythonexecutable"
11.68 npm ERR! gyp ERR! find Python For more information consult the documentation at:
11.68 npm ERR! gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
11.68 npm ERR! gyp ERR! find Python **********************************************************
11.68 npm ERR! gyp ERR! find Python 
11.68 npm ERR! gyp ERR! configure error 
11.68 npm ERR! gyp ERR! stack Error: Could not find any Python installation to use
11.68 npm ERR! gyp ERR! stack     at PythonFinder.fail (/app/node_modules/node-gyp/lib/find-python.js:330:47)
11.68 npm ERR! gyp ERR! stack     at PythonFinder.runChecks (/app/node_modules/node-gyp/lib/find-python.js:159:21)
11.68 npm ERR! gyp ERR! stack     at PythonFinder.<anonymous> (/app/node_modules/node-gyp/lib/find-python.js:202:16)
11.68 npm ERR! gyp ERR! stack     at PythonFinder.execFileCallback (/app/node_modules/node-gyp/lib/find-python.js:294:16)
11.68 npm ERR! gyp ERR! stack     at exithandler (node:child_process:430:5)
11.68 npm ERR! gyp ERR! stack     at ChildProcess.errorhandler (node:child_process:442:5)
11.68 npm ERR! gyp ERR! stack     at ChildProcess.emit (node:events:514:28)
11.68 npm ERR! gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:292:12)
11.68 npm ERR! gyp ERR! stack     at onErrorNT (node:internal/child_process:484:16)
11.68 npm ERR! gyp ERR! stack     at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
11.68 npm ERR! gyp ERR! System Linux 6.4.16-linuxkit
11.68 npm ERR! gyp ERR! command "/usr/local/bin/node" "/app/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
11.68 npm ERR! gyp ERR! cwd /app/node_modules/node-sass
11.68 npm ERR! gyp ERR! node -v v20.9.0
11.68 npm ERR! gyp ERR! node-gyp -v v8.4.1
11.68 npm ERR! gyp ERR! not ok 
11.68 npm ERR! Build failed with error code: 1
```